### PR TITLE
Add notion of tagset and expand user entities to support multiple tagsets - closes Server 119

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cherrytwist-server",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cherrytwist-server",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Cherrytwist back-end server that manages the representation of the ecoverse and all the entities stored wthin it",
   "main": "server.js",
   "author": "",

--- a/src/db-mgmt/load-sample-data.ts
+++ b/src/db-mgmt/load-sample-data.ts
@@ -59,8 +59,8 @@ async function load_sample_data() {
   // Challenges
   const energyWeb = new Challenge('Energy Web');
   energyWeb.initialiseMembers();
-  if (!energyWeb.tags) throw new Error("cannot reach this");
-  energyWeb.tags.addTag('java');
+  if (!energyWeb.tagset) throw new Error("cannot reach this");
+  energyWeb.tagset.addTag('java');
   energyWeb.context = new Context();
   energyWeb.context.tagline = 'Web of energy';
   const ref1 = new Reference('video', 'http://localhost:8443/myVid', 'Video explainer for the challenge');
@@ -73,8 +73,8 @@ async function load_sample_data() {
 
   const cleanOceans = new Challenge('Clean Oceans');
   cleanOceans.initialiseMembers();
-  if (!cleanOceans.tags) throw new Error("cannot reach this");
-  cleanOceans.tags.addTag('Nature');
+  if (!cleanOceans.tagset) throw new Error("cannot reach this");
+  cleanOceans.tagset.addTag('Nature');
   cleanOceans.context = new Context();
   cleanOceans.context.tagline = 'Keep our Oceans clean and in balance!';
   const cleanOceanMembers = UserGroup.getGroupByName(ctverse, 'members');
@@ -84,8 +84,8 @@ async function load_sample_data() {
 
   const cargoInsurance = new Challenge('Cargo Insurance');
   cargoInsurance.initialiseMembers();
-  if (!cargoInsurance.tags) throw new Error("cannot reach this");
-  cargoInsurance.tags.addTag('Logistics');
+  if (!cargoInsurance.tagset) throw new Error("cannot reach this");
+  cargoInsurance.tagset.addTag('Logistics');
   cargoInsurance.context = new Context();
   cargoInsurance.context.tagline = 'In an interconnected world, how to manage risk along the chain?';
   const cargoInsuranceMembers = UserGroup.getGroupByName(ctverse, 'members');

--- a/src/db-mgmt/load-sample-data.ts
+++ b/src/db-mgmt/load-sample-data.ts
@@ -59,7 +59,7 @@ async function load_sample_data() {
   // Challenges
   const energyWeb = new Challenge('Energy Web');
   energyWeb.initialiseMembers();
-  if (!energyWeb.tagset) throw new Error("cannot reach this");
+  if (!energyWeb.tagset) throw new Error('cannot reach this');
   energyWeb.tagset.addTag('java');
   energyWeb.context = new Context();
   energyWeb.context.tagline = 'Web of energy';
@@ -73,8 +73,9 @@ async function load_sample_data() {
 
   const cleanOceans = new Challenge('Clean Oceans');
   cleanOceans.initialiseMembers();
-  if (!cleanOceans.tagset) throw new Error("cannot reach this");
+  if (!cleanOceans.tagset) throw new Error('cannot reach this');
   cleanOceans.tagset.addTag('Nature');
+  cleanOceans.tagset.addTag('Test');
   cleanOceans.context = new Context();
   cleanOceans.context.tagline = 'Keep our Oceans clean and in balance!';
   const cleanOceanMembers = UserGroup.getGroupByName(ctverse, 'members');
@@ -84,7 +85,7 @@ async function load_sample_data() {
 
   const cargoInsurance = new Challenge('Cargo Insurance');
   cargoInsurance.initialiseMembers();
-  if (!cargoInsurance.tagset) throw new Error("cannot reach this");
+  if (!cargoInsurance.tagset) throw new Error('cannot reach this');
   cargoInsurance.tagset.addTag('Logistics');
   cargoInsurance.context = new Context();
   cargoInsurance.context.tagline = 'In an interconnected world, how to manage risk along the chain?';

--- a/src/db-mgmt/load-sample-data.ts
+++ b/src/db-mgmt/load-sample-data.ts
@@ -1,4 +1,4 @@
-import { Challenge, Context, Ecoverse, Reference, Tag, User, UserGroup } from '../models';
+import { Challenge, Context, Ecoverse, Reference, Tag, Tagset, User, UserGroup } from '../models';
 import { LoadConfiguration } from '../configuration-loader';
 import { ConnectionFactory } from '../connection-factory';
 
@@ -15,7 +15,7 @@ async function load_sample_data() {
 
   console.log('Loading sample data....');
   // Populate the Ecoverse beyond the defaults
-  const ctverse = await Ecoverse.getInstance();
+  const ctverse = await Ecoverse.findOneOrFail();
   ctverse.initialiseMembers();
   ctverse.name = 'Cherrytwist dogfood';
   ctverse.context.tagline = 'Powering multi-stakeholder collaboration!';
@@ -29,17 +29,22 @@ async function load_sample_data() {
 
   // Users
   const john = new User('john');
+  john.initialiseMembers();
   const bob = new User('bob');
+  bob.initialiseMembers()
   bob.email = 'admin@cherrytwist.org';
   const valentin = new User('Valentin');
+  valentin.initialiseMembers()
   valentin.email = 'valentin_yanakiev@yahoo.co.uk';
   const angel = new User('Angel');
+  angel.initialiseMembers
   angel.email = 'angel@cmd.bg';
-  const rene = new User('Rene');
-  const rutger = new User('Rutger');
-  const alex = new User('Alex');
   const neil = new User('Neil');
-  bob.tags = [java, graphql];
+  neil.initialiseMembers();
+  neil.email = 'neil@cherrytwist.org';
+  const defaultTagset = Tagset.defaultTagset(bob);
+  defaultTagset.addTag('java');
+  defaultTagset.addTag('graphql');
 
   // User Groups
   const members = UserGroup.getGroupByName(ctverse, 'members');
@@ -54,7 +59,8 @@ async function load_sample_data() {
   // Challenges
   const energyWeb = new Challenge('Energy Web');
   energyWeb.initialiseMembers();
-  energyWeb.tags = [java, graphql, industry];
+  if (!energyWeb.tags) throw new Error("cannot reach this");
+  energyWeb.tags.addTag('java');
   energyWeb.context = new Context();
   energyWeb.context.tagline = 'Web of energy';
   const ref1 = new Reference('video', 'http://localhost:8443/myVid', 'Video explainer for the challenge');
@@ -67,7 +73,8 @@ async function load_sample_data() {
 
   const cleanOceans = new Challenge('Clean Oceans');
   cleanOceans.initialiseMembers();
-  cleanOceans.tags = [graphql, nature];
+  if (!cleanOceans.tags) throw new Error("cannot reach this");
+  cleanOceans.tags.addTag('Nature');
   cleanOceans.context = new Context();
   cleanOceans.context.tagline = 'Keep our Oceans clean and in balance!';
   const cleanOceanMembers = UserGroup.getGroupByName(ctverse, 'members');
@@ -77,12 +84,13 @@ async function load_sample_data() {
 
   const cargoInsurance = new Challenge('Cargo Insurance');
   cargoInsurance.initialiseMembers();
-  cargoInsurance.tags = [graphql, java, industry];
+  if (!cargoInsurance.tags) throw new Error("cannot reach this");
+  cargoInsurance.tags.addTag('Logistics');
   cargoInsurance.context = new Context();
   cargoInsurance.context.tagline = 'In an interconnected world, how to manage risk along the chain?';
   const cargoInsuranceMembers = UserGroup.getGroupByName(ctverse, 'members');
-  cargoInsuranceMembers.members = [rutger, rene, alex];
-  cargoInsuranceMembers.focalPoint = rene;
+  cargoInsuranceMembers.members = [angel, valentin, neil];
+  cargoInsuranceMembers.focalPoint = angel;
   cargoInsurance.groups = [cargoInsuranceMembers];
 
   ctverse.challenges = [cleanOceans, energyWeb, cargoInsurance];

--- a/src/graphql-samples/mutations/create/create-tagset-on-user
+++ b/src/graphql-samples/mutations/create/create-tagset-on-user
@@ -1,0 +1,16 @@
+mutation createTagsetOnUser($tagsetName: String!, $userID: Float!) {
+  createTagsetOnUser(tagsetName: $tagsetName, userID: $userID) {
+    name,
+    id
+    tagsets {
+      name
+    }
+
+  }
+}
+
+Variables:
+{
+  "userID": 1,
+  "tagsetName": "testTagset"
+}

--- a/src/graphql-samples/mutations/update/update-tags-on-tagset
+++ b/src/graphql-samples/mutations/update/update-tags-on-tagset
@@ -1,0 +1,19 @@
+mmutation updateTagsOnTagset($tagsInput: TagsInput!, $tagsetID: Float!) {
+  updateTagsOnTagset(tags: $tagsInput, tagsetID: $tagsetID) {
+    name,
+    tags
+  }
+}
+
+
+query variables:
+{
+  "tagsetID": 4,
+  "tagsInput": {
+    "tags": [
+              "tag1",
+              "tag2"
+            ]
+  }
+
+}

--- a/src/interfaces/IChallenge.ts
+++ b/src/interfaces/IChallenge.ts
@@ -4,13 +4,14 @@ import { IUserGroup } from './IUserGroup';
 import { IOrganisation } from './IOrganisation';
 import { IUser } from './IUser';
 import { IProject } from './IProject';
+import { ITagset } from './ITagset';
 
 export interface IChallenge {
   id: number;
   name: string;
   lifecyclePhase?: string;
   context?: IContext;
-  tags?: ITag[];
+  tagset: ITagset;
   groups?: IUserGroup[];
   contributors?: IUser[];
   projects?: IProject[];

--- a/src/interfaces/IChallenge.ts
+++ b/src/interfaces/IChallenge.ts
@@ -1,4 +1,3 @@
-import { ITag } from './ITag';
 import { IContext } from './IContext';
 import { IUserGroup } from './IUserGroup';
 import { IOrganisation } from './IOrganisation';

--- a/src/interfaces/ITagset.ts
+++ b/src/interfaces/ITagset.ts
@@ -1,0 +1,5 @@
+export interface ITagset {
+  id: number;
+  name: string;
+  tags?: string[];
+}

--- a/src/interfaces/IUser.ts
+++ b/src/interfaces/IUser.ts
@@ -4,10 +4,8 @@ import { IDID } from './IDID';
 export interface IUser {
   id: number;
   name: string;
-  account: string;
   firstName: string;
   lastName: string;
   email: string;
   DID: IDID;
-  tags?: ITag[];
 }

--- a/src/models/entities/Challenge.ts
+++ b/src/models/entities/Challenge.ts
@@ -12,7 +12,7 @@ import {
   ManyToMany,
   JoinTable,
 } from 'typeorm';
-import { DID, Tag, User, UserGroup, Context, Ecoverse, Project, RestrictedGroupNames } from '.';
+import { DID, Tag, User, UserGroup, Context, Ecoverse, Project, RestrictedGroupNames, Tagset, RestrictedTagsetNames } from '.';
 import { Organisation } from './Organisation';
 import { IChallenge } from 'src/interfaces/IChallenge';
 import { IGroupable } from '../interfaces';
@@ -63,10 +63,10 @@ export class Challenge extends BaseEntity implements IChallenge, IGroupable {
   @Column({ nullable: true })
   lifecyclePhase?: string;
 
-  @Field(() => [Tag], { nullable: true, description: 'The set of tags to label the challenge' })
-  @ManyToMany(() => Tag, tag => tag.ecoverses, { eager: true, cascade: true })
-  @JoinTable({ name: 'challenge_tag' })
-  tags?: Tag[];
+  @Field(() => Tagset, { nullable: true, description: 'The set of tags for the challenge' })
+  @OneToOne(() => Tagset, { eager: true, cascade: true })
+  @JoinColumn()
+  tagset: Tagset;
 
   @Field(() => [Project], { nullable: true, description: 'The set of projects within the context of this challenge' })
   @OneToMany(() => Project, project => project.challenge, { eager: true, cascade: true })
@@ -86,6 +86,8 @@ export class Challenge extends BaseEntity implements IChallenge, IGroupable {
     super();
     this.name = name;
     this.context = new Context();
+    this.tagset = new Tagset(RestrictedTagsetNames.Default);
+    this.tagset.initialiseMembers();
     this.restrictedGroupNames = [RestrictedGroupNames.Members];
   }
 
@@ -101,10 +103,6 @@ export class Challenge extends BaseEntity implements IChallenge, IGroupable {
     }
     // Check that the mandatory groups for a challenge are created
     UserGroup.addMandatoryGroups(this, this.restrictedGroupNames);
-
-    if (!this.tags) {
-      this.tags = [];
-    }
 
     if (!this.projects) {
       this.projects = [];

--- a/src/models/entities/Challenge.ts
+++ b/src/models/entities/Challenge.ts
@@ -12,7 +12,7 @@ import {
   ManyToMany,
   JoinTable,
 } from 'typeorm';
-import { DID, Tag, User, UserGroup, Context, Ecoverse, Project, RestrictedGroupNames, Tagset, RestrictedTagsetNames } from '.';
+import { DID, User, UserGroup, Context, Ecoverse, Project, RestrictedGroupNames, Tagset, RestrictedTagsetNames } from '.';
 import { Organisation } from './Organisation';
 import { IChallenge } from 'src/interfaces/IChallenge';
 import { IGroupable } from '../interfaces';

--- a/src/models/entities/Ecoverse.ts
+++ b/src/models/entities/Ecoverse.ts
@@ -88,6 +88,7 @@ export class Ecoverse extends BaseEntity implements IEcoverse, IGroupable {
 
     // Find the admin user and put that person in as member + admin
     const adminUser = new User('admin');
+    adminUser.initialiseMembers();
     const admins = UserGroup.getGroupByName(ecoverse, RestrictedGroupNames.Admins);
     const members = UserGroup.getGroupByName(ecoverse, RestrictedGroupNames.Members);
     admins.addUserToGroup(adminUser);

--- a/src/models/entities/Tag.ts
+++ b/src/models/entities/Tag.ts
@@ -1,6 +1,6 @@
 import { Field, ID, ObjectType } from 'type-graphql';
 import { BaseEntity, Column, Entity, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
-import { Agreement, Challenge, Ecoverse, Organisation, Project, User, UserGroup } from '.';
+import { Agreement, Ecoverse, Organisation, Project, UserGroup } from '.';
 import { ITag } from 'src/interfaces/ITag';
 
 @Entity()

--- a/src/models/entities/Tag.ts
+++ b/src/models/entities/Tag.ts
@@ -14,9 +14,6 @@ export class Tag extends BaseEntity implements ITag {
   @Column()
   name: string;
 
-  @ManyToMany(() => Challenge, challenge => challenge.tags)
-  challenges?: Challenge;
-
   @ManyToMany(() => Project, project => project.tags)
   projects?: Project;
 
@@ -25,9 +22,6 @@ export class Tag extends BaseEntity implements ITag {
 
   @ManyToMany(() => Ecoverse, ecoverse => ecoverse.tags)
   ecoverses?: Ecoverse[];
-
-  @ManyToMany(() => User, user => user.tags)
-  users?: User;
 
   @ManyToMany(() => UserGroup, userGroup => userGroup.tags)
   userGroups?: UserGroup;

--- a/src/models/entities/Tagset.ts
+++ b/src/models/entities/Tagset.ts
@@ -1,0 +1,79 @@
+import { Field, ID, ObjectType } from 'type-graphql';
+import { BaseEntity, Column, Entity, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { User } from '.';
+import { ITag } from 'src/interfaces/ITag';
+import { ITaggable } from '../interfaces';
+import { ITagset } from 'src/interfaces/ITagset';
+
+@Entity()
+@ObjectType()
+export class Tagset extends BaseEntity implements ITagset {
+  @Field(() => ID)
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Field(() => String)
+  @Column()
+  name: string;
+
+  @Field(() => [String])
+  @Column("simple-array")
+  tags?: string[];
+
+  @ManyToOne(() => User, user => user.tagsets)
+  user?: User;
+
+  /* Adds a tag, returning boolean for whether the tag was newly added or not */
+  addTag(tagName: string): boolean {
+    // Check that the tag does not already exist
+    if (!this.tags?.includes(tagName)) {
+      this.tags?.push(tagName);
+      return true;
+    }
+    return false;
+
+  }
+
+  constructor(name: string) {
+    super();
+    this.name = name;
+  }
+
+  // Helper method to ensure all members are initialised properly.
+  // Note: has to be a seprate call due to restrictions from ORM.
+  initialiseMembers(): Tagset {
+    if (!this.tags) {
+      this.tags = [];
+    }
+
+    return this;
+  }
+
+  static createRestrictedTagsets(taggable: ITaggable, names: string[]): boolean {
+    if (!taggable.restrictedTagsetNames) {
+      throw new Error('Non-initialised Taggable submitted');
+    }
+    for (const name of names) {
+      const tagset = new Tagset(name);
+      tagset.initialiseMembers();
+      taggable.tagsets?.push(tagset);
+    }
+    return true;
+  }
+
+  // Get the default tagset
+  static defaultTagset(taggable: ITaggable): Tagset {
+    if (!taggable.tagsets) throw new Error("Tagsets not initialised");
+    for (const tagset of taggable.tagsets) {
+      if (tagset.name === RestrictedTagsetNames.Default) {
+        return tagset;
+      }
+   }
+    throw new Error("Unable to find default tagset");
+  }
+}
+
+export enum RestrictedTagsetNames {
+  Default = 'default',
+  Skills = 'skills',
+}

--- a/src/models/entities/Tagset.ts
+++ b/src/models/entities/Tagset.ts
@@ -1,7 +1,6 @@
 import { Field, ID, ObjectType } from 'type-graphql';
 import { BaseEntity, Column, Entity, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
 import { User } from '.';
-import { ITag } from 'src/interfaces/ITag';
 import { ITaggable } from '../interfaces';
 import { ITagset } from 'src/interfaces/ITagset';
 
@@ -17,7 +16,7 @@ export class Tagset extends BaseEntity implements ITagset {
   name: string;
 
   @Field(() => [String])
-  @Column("simple-array")
+  @Column('simple-array')
   tags?: string[];
 
   @ManyToOne(() => User, user => user.tagsets)
@@ -63,13 +62,13 @@ export class Tagset extends BaseEntity implements ITagset {
 
   // Get the default tagset
   static defaultTagset(taggable: ITaggable): Tagset {
-    if (!taggable.tagsets) throw new Error("Tagsets not initialised");
+    if (!taggable.tagsets) throw new Error('Tagsets not initialised');
     for (const tagset of taggable.tagsets) {
       if (tagset.name === RestrictedTagsetNames.Default) {
         return tagset;
       }
    }
-    throw new Error("Unable to find default tagset");
+    throw new Error('Unable to find default tagset');
   }
 }
 

--- a/src/models/entities/Tagset.ts
+++ b/src/models/entities/Tagset.ts
@@ -70,6 +70,57 @@ export class Tagset extends BaseEntity implements ITagset {
    }
     throw new Error('Unable to find default tagset');
   }
+
+  static hasTagsetWithName(taggable: ITaggable, name: string): boolean {
+    // Double check groups array is initialised
+    if (!taggable.tagsets) {
+      throw new Error('Non-initialised Tagsets submitted');
+    }
+
+    // Find the right group
+    for (const tagset of taggable.tagsets) {
+      if (tagset.name === name) {
+        return true;
+      }
+    }
+
+    // If get here then no match group was found
+    return false;
+  }
+
+  static getTagsetByName(taggable: ITaggable, name: string): Tagset {
+    // Double check groups array is initialised
+    if (!taggable.tagsets) {
+      throw new Error('Non-initialised Taggable submitted');
+    }
+
+    for (const tagset of taggable.tagsets) {
+      if (tagset.name === name) {
+        return tagset;
+      }
+    }
+
+    // If get here then no match group was found
+    throw new Error('Unable to find tagset with the name:' + { name });
+  }
+
+  static addTagsetWithName(taggable: ITaggable, name: string): Tagset {
+    // Check if the group already exists, if so log a warning
+    if (this.hasTagsetWithName(taggable, name)) {
+      // TODO: log a warning
+      return this.getTagsetByName(taggable, name);
+    }
+
+    if (taggable.restrictedTagsetNames?.includes(name)) {
+      console.log(`Attempted to create a tagset using a restricted name: ${name}`);
+      throw new Error('Unable to create tagset with restricted name: ' + { name });
+    }
+
+    const newTagset = new Tagset(name);
+    newTagset.initialiseMembers();
+    taggable.tagsets?.push(newTagset);
+    return newTagset;
+  }
 }
 
 export enum RestrictedTagsetNames {

--- a/src/models/entities/UserGroup.ts
+++ b/src/models/entities/UserGroup.ts
@@ -159,7 +159,6 @@ export class UserGroup extends BaseEntity implements IUserGroup {
     for (const name of names) {
       const group = new UserGroup(name);
       groupable.groups?.push(group);
-      groupable.restrictedGroupNames.push(name);
     }
 
     // Todo: is this the right return type?

--- a/src/models/entities/index.ts
+++ b/src/models/entities/index.ts
@@ -9,3 +9,4 @@ export * from './Context';
 export * from './Project';
 export * from './Agreement';
 export * from './Reference';
+export * from './Tagset';

--- a/src/models/interfaces/ITaggable.ts
+++ b/src/models/interfaces/ITaggable.ts
@@ -1,0 +1,6 @@
+import { UserGroup, Tagset } from '../entities';
+
+export interface ITaggable {
+  tagsets?: Tagset[];
+  restrictedTagsetNames?: string[];
+}

--- a/src/models/interfaces/index.ts
+++ b/src/models/interfaces/index.ts
@@ -1,1 +1,3 @@
 export * from './IGroupable';
+export * from './ITaggable';
+

--- a/src/schema/inputs/ChallengeInput.ts
+++ b/src/schema/inputs/ChallengeInput.ts
@@ -2,8 +2,8 @@ import { MaxLength } from 'class-validator';
 import { Field, InputType } from 'type-graphql';
 import {
   ContextInput,
-  TagInput,
-  UpdateNestedTagInput,
+  TagsetInput,
+  UpdateNestedTagsetInput,
   UpdateNestedContextInput,
   UserGroupInput,
   UpdateNestedUserGroupInput,
@@ -23,8 +23,8 @@ export class ChallengeInput {
   @MaxLength(255)
   lifecyclePhase?: string;
 
-  @Field(() => [TagInput], { nullable: true })
-  tags?: TagInput[];
+  @Field(() => TagsetInput, { nullable: true })
+  tags?: TagsetInput;
 
   @Field(() => ContextInput, { nullable: true })
   context?: ContextInput;
@@ -47,8 +47,8 @@ export class BaseUpdateChallengeInput {
   @MaxLength(255)
   lifecyclePhase?: string;
 
-  @Field(() => [UpdateNestedTagInput], { nullable: true })
-  tags?: UpdateNestedTagInput[];
+  @Field(() => UpdateNestedTagsetInput, { nullable: true })
+  tags?: UpdateNestedTagsetInput;
 
   @Field(() => UpdateNestedContextInput, { nullable: true })
   context?: UpdateNestedContextInput;

--- a/src/schema/inputs/TagsInput.ts
+++ b/src/schema/inputs/TagsInput.ts
@@ -1,0 +1,8 @@
+import { InputType, Field } from 'type-graphql';
+
+@InputType()
+export class TagsInput {
+  @Field(() => [String], { nullable: true })
+  tags?: string[];
+}
+

--- a/src/schema/inputs/TagsetInput.ts
+++ b/src/schema/inputs/TagsetInput.ts
@@ -1,0 +1,22 @@
+import { InputType, Field } from 'type-graphql';
+import { MaxLength } from 'class-validator';
+
+@InputType()
+export class TagsetInput {
+  @Field({ nullable: true })
+  @MaxLength(30)
+  name?: string;
+  tags?: string[];
+}
+
+@InputType()
+export class UpdateNestedTagsetInput extends TagsetInput {
+  @Field()
+  id!: number;
+}
+
+@InputType()
+export class UpdateRootTagsetInput extends TagsetInput {
+  @Field({ nullable: true })
+  id?: number;
+}

--- a/src/schema/inputs/UserInput.ts
+++ b/src/schema/inputs/UserInput.ts
@@ -24,8 +24,6 @@ export class UserInput {
   @MaxLength(120)
   email?: string;
 
-  @Field(() => [TagInput], { nullable: true })
-  tags?: TagInput[];
 }
 
 @InputType()
@@ -50,8 +48,6 @@ export class BaseUpdateUserInput {
   @MaxLength(120)
   email?: string;
 
-  @Field(() => [UpdateNestedTagInput], { nullable: true })
-  tags?: UpdateNestedTagInput[];
 }
 
 @InputType()

--- a/src/schema/inputs/index.ts
+++ b/src/schema/inputs/index.ts
@@ -7,4 +7,5 @@ export * from './OrganisationInput';
 export * from './UserGroupInput';
 export * from './ProjectInput';
 export * from './TagInput';
+export * from './TagsetInput';
 export * from './ReferenceInput';

--- a/src/schema/resolvers/CreateMutations.ts
+++ b/src/schema/resolvers/CreateMutations.ts
@@ -1,7 +1,7 @@
 import { Arg, Mutation, Resolver } from 'type-graphql';
-import { Challenge, Context, Ecoverse, Organisation, Tag, User, UserGroup } from '../../models';
+import { Challenge, Context, Ecoverse, Organisation, Tag, Tagset, User, UserGroup } from '../../models';
 import { ChallengeInput, ContextInput, OrganisationInput, TagInput, UserGroupInput, UserInput } from '../inputs';
-import { EcoverseService, OrganisationService } from '../../services';
+import { EcoverseService, OrganisationService, UserService } from '../../services';
 import Container, { Inject } from 'typedi';
 import {  } from '../../services/OrganisationService';
 import { ApolloError } from 'apollo-server-express';
@@ -42,7 +42,7 @@ export class CreateMutations {
     return userGroup;
   }
 
-  @Mutation(() => UserGroup)
+  @Mutation(() => UserGroup, { description: 'Creates a new user group at the ecoverse level' })
   async createGroupOnEcoverse(
     @Arg('groupName') groupName: string): Promise<UserGroup> {
 
@@ -54,7 +54,7 @@ export class CreateMutations {
     return group;
   }
 
-  @Mutation(() => Challenge)
+  @Mutation(() => Challenge, { description: 'Creates a new user group for the challenge with the given id' })
   async createGroupOnChallenge(
     @Arg('challengeID') challengeID: number,
     @Arg('groupName') groupName: string
@@ -74,7 +74,7 @@ export class CreateMutations {
     return challenge;
   }
 
-  @Mutation(() => Organisation)
+  @Mutation(() => Organisation, { description: 'Creates a new user group for the organisation with the given id' })
   async createGroupOnOrganisation(
     @Arg('organisationID') organisationID: number,
     @Arg('groupName') groupName: string
@@ -88,6 +88,22 @@ export class CreateMutations {
     await organisation.save();
 
     return organisation;
+  }
+
+  @Mutation(() => User, { description: 'Creates a new tagset with the specified name for the user with given id' })
+  async createTagsetOnUser(
+    @Arg('userID') userID: number,
+    @Arg('tagsetName') tagsetName: string
+  ): Promise<User> {
+    const userService = Container.get<UserService>('UserService');
+    const user = await userService.getUser(userID);
+
+    if (!user) throw new ApolloError(`User with id(${userID}) not found!`);
+
+    Tagset.addTagsetWithName(user, tagsetName);
+    await user.save();
+
+    return user;
   }
 
   @Mutation(() => Organisation)

--- a/src/services/TagsetService.ts
+++ b/src/services/TagsetService.ts
@@ -1,0 +1,11 @@
+import { Tagset } from '../models';
+import { Service } from 'typedi';
+
+@Service('TagsetService')
+export class TagsetService {
+
+  public async getTagset(id: number): Promise<Tagset | undefined> {
+    const tagset = await Tagset.findOne({ where: { id } });
+    return tagset;
+  }
+}

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,0 +1,11 @@
+import { User } from '../models';
+import { Service } from 'typedi';
+
+@Service('UserService')
+export class UserService {
+
+  public async getUser(id: number): Promise<User | undefined> {
+    const user = await User.findOne({ where: { id } });
+    return user;
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,5 @@
 export * from './OrganisationService';
 export * from './EcoverseService';
 export * from './ChallengeService';
+export * from './UserService';
+export * from './TagsetService';


### PR DESCRIPTION
### Describe the background of your pull request

Adds new entity: Tagset
Adds business logic for working with tagsets to the Tagset class
New interface for manipulating tagsets (ITaggable)
Creates new services for Tagsets & Users
New mutations: createTagsetOnUser, updateTagsOnTagset
Loading of sample data

Updated version number to 0.1.7


### Additional context

There will need to be updates made to the json files used for loading in data e.g. demo project, Odyssey. To be taken as part of a wider set of updates around tags. 
 
