### PR TITLE
Role guards. Enables authorisation based on CT groups. Closes #238.

### DIFF
--- a/src/domain/ecoverse/ecoverse.resolver.mutations.ts
+++ b/src/domain/ecoverse/ecoverse.resolver.mutations.ts
@@ -1,7 +1,8 @@
-import { Get, Inject, UseGuards } from '@nestjs/common';
+import { Inject, UseGuards } from '@nestjs/common';
 import { Resolver } from '@nestjs/graphql';
 import { Args, Mutation } from '@nestjs/graphql/dist/decorators';
 import { GqlAuthGuard } from 'src/utils/authentication/graphql.guard';
+import { Roles } from 'src/utils/decorators/roles.decorator';
 import { ChallengeInput } from '../challenge/challenge.dto';
 import { Challenge } from '../challenge/challenge.entity';
 import { IChallenge } from '../challenge/challenge.interface';
@@ -44,7 +45,7 @@ export class EcoverseResolverMutations {
     return ctVerse;
   }
 
-  @Get()
+  @Roles('admins')
   @UseGuards(GqlAuthGuard)
   @Mutation(() => User, {
     description: 'Creates a new user as a member of the ecoverse',

--- a/src/domain/ecoverse/ecoverse.resolver.queries.ts
+++ b/src/domain/ecoverse/ecoverse.resolver.queries.ts
@@ -1,5 +1,7 @@
-import { Inject } from '@nestjs/common';
+import { Inject, UseGuards } from '@nestjs/common';
 import { Args, Query, Resolver } from '@nestjs/graphql';
+import { GqlAuthGuard } from 'src/utils/authentication/graphql.guard';
+import { Roles } from 'src/utils/decorators/roles.decorator';
 import { Challenge } from '../challenge/challenge.entity';
 import { IChallenge } from '../challenge/challenge.interface';
 import { ChallengeService } from '../challenge/challenge.service';
@@ -45,8 +47,6 @@ export class EcoverseResolverQueries {
     return members;
   }
 
-  //@Get()
-  //@UseGuards(GqlAuthGuard)
   @Query(() => Organisation, {
     nullable: false,
     description: 'The host organisation for the ecoverse',

--- a/src/domain/user/user.dto.ts
+++ b/src/domain/user/user.dto.ts
@@ -1,5 +1,6 @@
 import { Field, InputType } from '@nestjs/graphql';
 import { MaxLength } from 'class-validator';
+import { IUserGroup } from '../user-group/user-group.interface';
 
 @InputType()
 export class UserInput {
@@ -41,4 +42,14 @@ export class UserInput {
   @Field({ nullable: true })
   @MaxLength(30)
   aadPassword?: string;
+}
+
+export class AuthUserDTO {
+  email: string;
+  userGroups: IUserGroup[];
+
+  constructor(email: string, userGroups: IUserGroup[]) {
+    this.email = email;
+    this.userGroups = userGroups;
+  }
 }

--- a/src/domain/user/user.interface.ts
+++ b/src/domain/user/user.interface.ts
@@ -1,5 +1,6 @@
 import { IDID } from '../did/did.interface';
 import { IProfile } from '../profile/profile.interface';
+import { IUserGroup } from '../user-group/user-group.interface';
 
 export interface IUser {
   id: number;
@@ -14,4 +15,5 @@ export interface IUser {
   gender: string;
   DID: IDID;
   profile: IProfile;
+  userGroups?: Promise<IUserGroup[]>;
 }

--- a/src/utils/authentication/graphql.guard.ts
+++ b/src/utils/authentication/graphql.guard.ts
@@ -5,10 +5,24 @@ import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context-hos
 import { AuthenticationError } from 'apollo-server-core';
 import { ConfigService } from '@nestjs/config';
 import { IServiceConfig } from 'src/interfaces/service.config.interface';
+import { Reflector } from '@nestjs/core';
+import { AuthUserDTO } from 'src/domain/user/user.dto';
+import { IUserGroup } from 'src/domain/user-group/user-group.interface';
 
 @Injectable()
 export class GqlAuthGuard extends AuthGuard('azure-ad') {
-  constructor(private configService: ConfigService) {
+  private _roles!: string[];
+  public get roles(): string[] {
+    return this._roles;
+  }
+  public set roles(value: string[]) {
+    this._roles = value;
+  }
+
+  constructor(
+    private configService: ConfigService,
+    private reflector: Reflector
+  ) {
     super();
   }
   canActivate(context: ExecutionContext) {
@@ -16,18 +30,33 @@ export class GqlAuthGuard extends AuthGuard('azure-ad') {
     const { req } = ctx.getContext();
     console.log(req);
 
+    const auth_roles = this.reflector.get<string[]>(
+      'roles',
+      context.getHandler()
+    );
+    this.roles = auth_roles;
+
     return super.canActivate(new ExecutionContextHost([req]));
+  }
+
+  matchRoles(userGroups: IUserGroup[]): boolean {
+    if (userGroups.some(({ name }) => this.roles.includes(name))) return true;
+    return false;
   }
 
   handleRequest(err: any, user: any) {
     if (
       this.configService.get<IServiceConfig>('service')
         ?.authenticationEnabled === 'false'
-    )
+    ) {
       return true;
+    }
     if (err || !user) {
       throw err || new AuthenticationError('GqlAuthGuard');
     }
-    return user;
+
+    const ctUser = user as AuthUserDTO;
+    if (this.matchRoles(ctUser.userGroups)) return user;
+    throw new AuthenticationError('GqlAuthGuard');
   }
 }

--- a/src/utils/decorators/roles.decorator.ts
+++ b/src/utils/decorators/roles.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const Roles = (...roles: string[]) => SetMetadata('roles', roles);


### PR DESCRIPTION
### Describe the background of your pull request

Added Auth Guards based on roles. The logic is the following - the code gets the names of all the groups the user is in and compares them against all the strings in the Roles decorator e.g. Roles('admin', 'member'). The user must be authenticated in order for this to work.

### Additional context
There could be a potential optimisation to combine the Roles and Guard decorators into one.
Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/cherrytwist/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/cherrytwist/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/cherrytwist/Coordination/blob/master/LICENSE 
     and the contributor license agreement: tba
 
