### PR TITLE
added support for a textID field on a challenge

### DIFF
--- a/graphql-samples/mutations/create/create-challenge
+++ b/graphql-samples/mutations/create/create-challenge
@@ -15,6 +15,7 @@ query variables:
   "challengeData":
   {
     "name": "Balance the grid",
+    "textID": "balance-grid",
     "context": {
         "tagline": "How might we incentivize consumers to communicate energy demand and production to allow all stakeholders to balance the grid?",
         "background": "Our power system is becoming increasingly more decentralized and complex. By using solar PV, consumers have become electricity producers as well, and the number of these ‘prosumers’ is increasing. All the while, the electricity demand is rising due to the electrification of transport and industry. Cities around the world are electrifying their public transport systems, but if all busses would be charged around the time people are in the kitchen preparing dinner, the current grid would not be able to cope. The energy sector is striving to make the best of these developments, but so far the sector remains fragmented with a large number of initiatives and pilots spread over start-ups, scale-ups, countries, DSOs, TSOs, utilities, and regulators. Balancing the power grid is and will be more and more difficult and expensive. While technological advances have already disrupted many areas of the power system and, for example, empowered consumers to become producers and traders of their own electricity, the balancing markets still resemble an exclusive club of the big industry players. How can we enable also small consumers and prosumers to contribute to balancing? ",

--- a/src/domain/challenge/challenge.dto.ts
+++ b/src/domain/challenge/challenge.dto.ts
@@ -10,6 +10,10 @@ export class ChallengeInput {
   name?: string;
 
   @Field({ nullable: true })
+  @MaxLength(15)
+  textID?: string;
+
+  @Field({ nullable: true })
   @MaxLength(255)
   lifecyclePhase?: string;
 

--- a/src/domain/challenge/challenge.entity.ts
+++ b/src/domain/challenge/challenge.entity.ts
@@ -41,6 +41,13 @@ export class Challenge extends BaseEntity implements IChallenge, IGroupable {
   @Column('varchar', { length: 100 })
   name: string;
 
+  @Field(() => String, {
+    nullable: false,
+    description: 'A short text identifier for this challenge',
+  })
+  @Column('varchar', { length: 15 })
+  textID: string;
+
   @Field(() => Context, {
     nullable: true,
     description: 'The shared understanding for the challenge',
@@ -122,9 +129,10 @@ export class Challenge extends BaseEntity implements IChallenge, IGroupable {
   // The restricted group names at the challenge level
   restrictedGroupNames: string[];
 
-  constructor(name: string) {
+  constructor(name: string, textID: string) {
     super();
     this.name = name;
+    this.textID = textID;
     this.restrictedGroupNames = [RestrictedGroupNames.Members];
   }
 }

--- a/src/domain/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge.service.ts
@@ -86,6 +86,16 @@ export class ChallengeService {
   }
 
   async createChallenge(challengeData: ChallengeInput): Promise<IChallenge> {
+    // Verify that required textID field is present and that it has the right format
+    const textID = challengeData.textID;
+    if (!textID) throw new Error('Required field textID not specified');
+    const expression = /^[a-zA-Z0-9.\-_]+$/;
+    const textIdCheck = expression.test(String(textID).toLowerCase());
+    if (!textIdCheck)
+      throw new Error(
+        `Required field textID provided not in the correct format: ${textID}`
+      );
+
     // reate and initialise a new challenge using the first returned array item
     const challenge = Challenge.create(challengeData);
     await this.initialiseMembers(challenge);

--- a/src/domain/ecoverse/ecoverse.service.ts
+++ b/src/domain/ecoverse/ecoverse.service.ts
@@ -26,7 +26,6 @@ import { AccountService } from '../../utils/account/account.service';
 import { Context } from '../context/context.entity';
 import { RestrictedTagsetNames, Tagset } from '../tagset/tagset.entity';
 
-
 @Injectable()
 export class EcoverseService {
   constructor(

--- a/src/utils/data-management/data-management.service.ts
+++ b/src/utils/data-management/data-management.service.ts
@@ -7,7 +7,6 @@ import { EcoverseService } from '../../domain/ecoverse/ecoverse.service';
 import { ProfileService } from '../../domain/profile/profile.service';
 import { Reference } from '../../domain/reference/reference.entity';
 import { Context } from '../../domain/context/context.entity';
-import { Tagset } from '../../domain/tagset/tagset.entity';
 import { TagsetService } from '../../domain/tagset/tagset.service';
 import { IUserGroup } from '../../domain/user-group/user-group.interface';
 import { UserGroupService } from '../../domain/user-group/user-group.service';
@@ -116,6 +115,7 @@ export class DataManagementService {
       // Challenges
       const energyWeb = await this.createChallenge(
         'Energy Web',
+        'energy-web',
         'Web of energy',
         ['java', 'graphql']
       );
@@ -142,6 +142,7 @@ export class DataManagementService {
 
       const cleanOceans = await this.createChallenge(
         'Clean Oceans',
+        'clean-oceans',
         'Keep our Oceans clean and in balance!',
         ['java', 'linux']
       );
@@ -157,6 +158,7 @@ export class DataManagementService {
 
       const cargoInsurance = await this.createChallenge(
         'Cargo Insurance',
+        'cargo-insurance',
         'In an interconnected world, how to manage risk along the chain?',
         ['logistics', 'eco']
       );
@@ -195,10 +197,12 @@ export class DataManagementService {
 
   async createChallenge(
     name: string,
+    textID: string,
     tagline?: string,
     tags?: string[]
   ): Promise<IChallenge> {
     const challengeInput = new ChallengeInput();
+    challengeInput.textID = textID;
     challengeInput.name = name;
     if (tagline) {
       challengeInput.context = {


### PR DESCRIPTION
### Describe the background of your pull request

Adds a new required field on a challenge: textID

### Additional context

This field is for usage on clients e.g. Client.Web so that they can generate unique URL paths for the challenge. It is fixed at challenge creation.
 
