### PR TITLE
Disable data-management with enabled authentication. Closes #296.

### DIFF
--- a/src/utils/data-management/data-management.controller.ts
+++ b/src/utils/data-management/data-management.controller.ts
@@ -1,12 +1,30 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { IServiceConfig } from '../../interfaces/service.config.interface';
 import { DataManagementService } from './data-management.service';
 
 @Controller('data-management')
 export class DataManagementController {
-  constructor(private readonly dataManagementService: DataManagementService) {}
+  constructor(
+    private readonly dataManagementService: DataManagementService,
+    private readonly configService: ConfigService
+  ) {}
+
+  authenticationEnabled(): boolean {
+    if (
+      this.configService.get<IServiceConfig>('service')
+        ?.authenticationEnabled === 'false'
+    )
+      return false;
+    return true;
+  }
 
   @Get()
   async dataMgmtHome() {
+    if (this.authenticationEnabled())
+      throw new UnauthorizedException(
+        'Data management endpoints are enabled only with disabled authentication!'
+      );
     const msg = 'Please select one of the options below';
     const content = await this.dataManagementService.populatePageContent(msg);
     return content;
@@ -14,6 +32,10 @@ export class DataManagementController {
 
   @Get('reset-db')
   async resetDB() {
+    if (this.authenticationEnabled())
+      throw new UnauthorizedException(
+        'Data management endpoints are enabled only with disabled authentication!'
+      );
     const msg = await this.dataManagementService.reset_to_empty_db();
     const content = await this.dataManagementService.populatePageContent(msg);
     return content;
@@ -21,6 +43,10 @@ export class DataManagementController {
 
   @Get('empty-ecoverse')
   async emptyEcoverse() {
+    if (this.authenticationEnabled())
+      throw new UnauthorizedException(
+        'Data management endpoints are enabled only with disabled authentication!'
+      );
     const msg = await this.dataManagementService.reset_to_empty_ecoverse();
     const content = await this.dataManagementService.populatePageContent(msg);
     return content;
@@ -28,6 +54,10 @@ export class DataManagementController {
 
   @Get('seed-data')
   async seedData() {
+    if (this.authenticationEnabled())
+      throw new UnauthorizedException(
+        'Data management endpoints are enabled only with disabled authentication!'
+      );
     const msg = await this.dataManagementService.load_sample_data();
     const content = await this.dataManagementService.populatePageContent(msg);
     return content;


### PR DESCRIPTION
### Describe the background of your pull request

Disable controller usage when authentication is enabled.

### Additional context

I have deliberately copied the code from AccountService instead of referring it. Adding the reference creates circular dependencies. Expecting this controller to be moved client-side so the code is a quick fix.

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/cherrytwist/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/cherrytwist/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/cherrytwist/Coordination/blob/master/LICENSE 
     and the contributor license agreement: tba
 
