### PR TITLE
Fixed WInston log level settings. Closes #421.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ CORS_ORIGIN=[your CORS origin value]
 To configure logging levels, use:
 
 ```conf
-LOGGING_LEVEL=Error|Warn|Info|Http|Verbose|Debug|Silly. Defaults to Error if no value is set.
+LOGGING_LEVEL=Error|Warn|Verbose|Debug. Defaults to Error if no value is set.
 ```
 
 ### Install dependencies

--- a/src/utils/config/winston.config.ts
+++ b/src/utils/config/winston.config.ts
@@ -12,7 +12,9 @@ export class WinstonConfigService {
             winston.format.timestamp(),
             nestWinstonModuleUtilities.format.nestLike()
           ),
-          level: process.env.LOGGING_LEVEL || LOGGING_LEVEL.Error.toString(),
+          level:
+            process.env.LOGGING_LEVEL?.toLowerCase() ||
+            LOGGING_LEVEL.Error.toString().toLowerCase(),
         }),
         // other transports...
       ],


### PR DESCRIPTION
### Describe the background of your pull request

Log levels can be configured now.

### Additional context

I have left the enum values if we decide to alter our Winston implementation. Currently, the levels in the README are the nest levels that match Winston levels (there is an implementation for those levels in the nest winston logger).

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/cherrytwist/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/cherrytwist/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/cherrytwist/Coordination/blob/master/LICENSE 
     and the contributor license agreement: tba
 
