### PR TITLE
Create DB if not present on start of container

### DIFF
--- a/.scripts/create_db.sh
+++ b/.scripts/create_db.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mysql --user=root --host=${DATABASE_HOST} --password=${MYSQL_ROOT_PASSWORD} -e "CREATE DATABASE IF NOT EXISTS ${MYSQL_DATABASE};"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:12-alpine
 
+
+#install CLI mariadb/mysql client
+RUN apk add --update mariadb-client && rm -rf /var/cache/apk/*
+
+
 # Create app directory
 WORKDIR /usr/src/app
 
@@ -27,5 +32,9 @@ RUN chmod +x /wait
 
 ENV GRAPHQL_ENDPOINT_PORT=${GRAPHQL_ENDPOINT_PORT_ARG}
 
+ADD .scripts/create_db.sh /create_db.sh
+RUN chmod +x /create_db.sh
+
+
 EXPOSE ${GRAPHQL_ENDPOINT_PORT_ARG}
-CMD [ "npm", "start" ]
+CMD ["/bin/sh", "-c", "/create_db.sh && npm start"]


### PR DESCRIPTION
fixing regression when DB is not created if missing.
While it is perfectly workable solution, ideologically more correct would be to create from code, as it was in 0.1.xx line