### PR TITLE
Fixed logged auth error. Closes #509.

### DIFF
--- a/src/utils/authentication/aad.strategy.ts
+++ b/src/utils/authentication/aad.strategy.ts
@@ -54,7 +54,7 @@ export class AzureADStrategy
     done: CallableFunction
   ): Promise<any> {
     try {
-      if (!token.email) throw new Error('Token email missing!');
+      if (!token.email) throw new AuthenticationError('Token email missing!');
 
       await this.cacheBearerToken(req);
 
@@ -71,7 +71,11 @@ export class AzureADStrategy
         error,
         LogContexts.AUTH
       );
-      done(new Error(`Failed adding the user to the request object: ${error}`));
+      done(
+        new AuthenticationError(
+          `Failed adding the user to the request object: ${error}`
+        )
+      );
     }
   }
 

--- a/src/utils/authentication/graphql.guard.ts
+++ b/src/utils/authentication/graphql.guard.ts
@@ -60,10 +60,16 @@ export class GqlAuthGuard extends AuthGuard('azure-ad') {
     if (err) throw err;
 
     if (!user) {
-      this.logger.error(info, LogContexts.AUTH);
-      throw new AuthenticationError(
-        'You are not authorized to access this resource.'
-      );
+      if (err) {
+        const authError = new AuthenticationError(
+          `You are not authorized to access this resource. ${err}`
+        );
+        this.logger.error(err, authError.message, LogContexts.AUTH);
+        throw authError;
+      } else {
+        this.logger.warn(info, LogContexts.AUTH);
+        return;
+      }
     }
 
     if (this.matchRoles(user.userGroups)) return user;

--- a/src/utils/authentication/graphql.guard.ts
+++ b/src/utils/authentication/graphql.guard.ts
@@ -48,7 +48,7 @@ export class GqlAuthGuard extends AuthGuard('azure-ad') {
     );
   }
 
-  handleRequest(err: any, user: any, info: any) {
+  handleRequest(err: any, user: any, _info: any) {
     // Always handle the request if authentication is disabled
     if (
       this.configService.get<IServiceConfig>('service')
@@ -59,18 +59,10 @@ export class GqlAuthGuard extends AuthGuard('azure-ad') {
 
     if (err) throw err;
 
-    if (!user) {
-      if (err) {
-        const authError = new AuthenticationError(
-          `You are not authorized to access this resource. ${err}`
-        );
-        this.logger.error(err, authError.message, LogContexts.AUTH);
-        throw authError;
-      } else {
-        this.logger.warn(info, LogContexts.AUTH);
-        return;
-      }
-    }
+    if (!user)
+      throw new AuthenticationError(
+        'You are not authorized to access this resource. '
+      );
 
     if (this.matchRoles(user.userGroups)) return user;
     throw new AuthenticationError(

--- a/src/utils/config/aad.config.ts
+++ b/src/utils/config/aad.config.ts
@@ -10,7 +10,9 @@ export default registerAs('aad', () => ({
   allowMultiAudiencesInToken: false,
   loggingLevel: process.env.AUTH_AAD_LOGGING_LEVEL || AAD_LOGGING_LEVEL.Error,
   scope: ['Cherrytwist-GraphQL'],
-  loggingNoPII: !process.env.AUTH_AAD_LOGGING_PII || true,
+  loggingNoPII: !(
+    process.env.AUTH_AAD_LOGGING_PII?.toString().toLocaleLowerCase() === 'true'
+  ),
   upnDomain:
     process.env.AUTH_AAD_UPN_DOMAIN || 'playgroundcherrytwist.onmicrosoft.com',
   tenant: process.env.AUTH_AAD_TENANT || '',


### PR DESCRIPTION
…raphql guard to throw error when handling requests only when the passportjs middleware has an actual error Showing a warning for requests that have no user (HTTP requests, user isn't added to the context there. GraphQL requests / context has it).

### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Please test before we pull it in.

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/cherrytwist/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/cherrytwist/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/cherrytwist/Coordination/blob/master/LICENSE 
     and the contributor license agreement: tba
 
