### PR TITLE
adding bettercodehub config

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,6 @@
+component_depth: 2
+default_excludes: true
+languages:
+- typescript
+- javascript
+- script


### PR DESCRIPTION
Hi @techsmyth , 

setting the component_depth to 2 or 3 gives the architects insight in how the components are coupled and balanced.

also could you enable the PR integration? Goto BCH and pres the little icon in the left bottom corner.
![Screenshot 2020-11-19 at 14 16 47](https://user-images.githubusercontent.com/18576001/99671114-dfd6cf00-2a71-11eb-81e9-ed33c7379083.jpg)

### Describe the background of your pull request

- adding the BCH config file
- requesting the administrator to enable PR integration for this repo, just click the icon in your BetterCodeHub.com


### Additional context

.bettercodehub.yml can be used to [configure](https://bettercodehub.com/docs/configuration-manual) the analysis
- exclude code
- assign code to the test domain if not doen automatically
- set the component_depth, this is the directory depth where the components are

### Governance 

- [X] No documentation is added
- [X] No test cases are added or updated
- [X] I've read the contributing document https://github.com/cherrytwist/.github/blob/master/CONTRIBUTING.md
- [X] I've read and understand the Code of Conduct https://github.com/cherrytwist/.github/blob/master/CODE_OF_CONDUCT.md
- [X] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/cherrytwist/Coordination/blob/master/LICENSE 
     and the contributor license agreement: tba
 
