### PR TITLE
Password reset PoC - Graph API is still not stable.

### DIFF
--- a/src/domain/ecoverse/ecoverse.resolver.mutations.ts
+++ b/src/domain/ecoverse/ecoverse.resolver.mutations.ts
@@ -1,4 +1,4 @@
-import { Inject, UseGuards } from '@nestjs/common';
+import { Inject, NotImplementedException, UseGuards } from '@nestjs/common';
 import { Resolver } from '@nestjs/graphql';
 import { Args, Mutation } from '@nestjs/graphql/dist/decorators';
 import { GqlAuthGuard } from '../../utils/authentication/graphql.guard';
@@ -116,6 +116,24 @@ export class EcoverseResolverMutations {
   async removeUser(@Args('userID') userID: number): Promise<boolean> {
     const success = await this.ecoverseService.removeUser(userID);
     return success;
+  }
+
+  @Roles(
+    RestrictedGroupNames.CommunityAdmins,
+    RestrictedGroupNames.EcoverseAdmins
+  )
+  @UseGuards(GqlAuthGuard)
+  @Mutation(() => Boolean, {
+    description: 'Updates the user account password',
+  })
+  @Profiling.api
+  async updateUserAccountPassword(@Args('userID') userID: number, @Args('newPassword') newPassword: string): Promise<boolean> {
+
+    throw new NotImplementedException('MS Graph API does not have production support for password update!');
+
+    //const success = await this.ecoverseService.updateUserAccountPassword(userID, newPassword);
+    //return success;
+
   }
 
   @Roles(RestrictedGroupNames.EcoverseAdmins)

--- a/src/domain/ecoverse/ecoverse.service.ts
+++ b/src/domain/ecoverse/ecoverse.service.ts
@@ -418,6 +418,17 @@ export class EcoverseService {
     return true;
   }
 
+
+  // Removes the user and deletes the profile
+  async updateUserAccountPassword(userID: number, newPassword: string): Promise<boolean> {
+    const user = await this.userService.getUserByID(userID);
+    if (!user) throw new Error(`Could not locate specified user: ${userID}`);
+
+    if (this.accountService.accountUsageEnabled())
+      return await this.accountService.updateUserAccountPassword(user.accountUpn, newPassword);
+    return true;
+  }
+
   async update(ecoverseData: EcoverseInput): Promise<IEcoverse> {
     const ecoverse = await this.getEcoverse();
 

--- a/src/utils/account/account.service.ts
+++ b/src/utils/account/account.service.ts
@@ -163,4 +163,31 @@ export class AccountService {
     if (res === undefined) return true;
     return false;
   }
+
+  async updateUserAccountPassword(accountUpn: string, newPassword: string): Promise<boolean> {
+    if (accountUpn === '') {
+      const error = new Error('Account UPN is missing!');
+      this.logger.error(
+        `Failed to reset password for account!`,
+        error.message,
+        LogContexts.COMMUNITY
+      );
+      throw error;
+    }
+
+    let res = false;
+    try {
+      res = await this.msGraphService.resetPassword(accountUpn, newPassword);
+    } catch (error) {
+      this.logger.error(
+        `Failed to reset password for account ${accountUpn}`,
+        error.message,
+        LogContexts.COMMUNITY
+      );
+    }
+
+    if (res === undefined) return true;
+    return false;
+  }
+
 }

--- a/src/utils/ms-graph/ms-graph.service.ts
+++ b/src/utils/ms-graph/ms-graph.service.ts
@@ -119,4 +119,28 @@ export class MsGraphService {
 
     return tenantName;
   }
+
+  async resetPassword(accountUpn: string, newPassword: string) : Promise<any>
+  {
+    const clientOptions: ClientOptions = {
+      authProvider: this.azureAdStrategy,
+    };
+
+    const passwordResetResponse =
+    {
+      newPassword: newPassword,
+    };
+
+    const client = Client.initWithMiddleware(clientOptions);
+    const userId = (await client.api(`/users/${accountUpn}?$select=id`).get()).id;
+    //https://docs.microsoft.com/en-us/graph/api/authentication-list-passwordmethods?view=graph-rest-beta&tabs=http
+    //we are parking this until the api call is moved to the production version of ms graph API
+    const req = `/users/${userId}/authentication/passwordMethods/${userId}/resetPassword`;
+    let res = await client.api(req)
+    .version('beta')
+    .post(passwordResetResponse);
+
+    return res;
+  }
+
 }


### PR DESCRIPTION
### Describe the background of your pull request

Password reset via MS Graph.

### Additional context

Graph API does **NOT** work. There is no production API to do password reset, only beta and it fails at the moment.
https://docs.microsoft.com/en-us/graph/api/passwordauthenticationmethod-resetpassword?view=graph-rest-beta&tabs=javascript

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/cherrytwist/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/cherrytwist/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/cherrytwist/Coordination/blob/master/LICENSE 
     and the contributor license agreement: tba
 
