### PR TITLE
moved addUserToOpportunity to Challenge level and extended business logic

### DIFF
--- a/graphql-samples/mutations/update/update-actor
+++ b/graphql-samples/mutations/update/update-actor
@@ -7,7 +7,7 @@ mutation updateActor($actorData: ActorInput!, $ID: Float!) {
 Variables:
 {
   "ID": 1,
-  "ActorData": {
+  "actorData": {
     "name": "some description",
     "value": "http://someUri",
     "impact": "http://someUri",

--- a/src/domain/challenge/challenge.resolver.fields.ts
+++ b/src/domain/challenge/challenge.resolver.fields.ts
@@ -59,14 +59,7 @@ export class ChallengeResolverFields {
   })
   @Profiling.api
   async contributors(@Parent() challenge: Challenge) {
-    const group = await this.userGroupService.getGroupByName(
-      challenge,
-      RestrictedGroupNames.Members
-    );
-    if (!group)
-      throw new Error(
-        `Unable to locate members group on challenge: ${challenge.name}`
-      );
+    const group = await this.challengeService.getMembersGroup(challenge);
     const members = group.members;
     if (!members)
       throw new Error(

--- a/src/domain/challenge/challenge.resolver.mutations.ts
+++ b/src/domain/challenge/challenge.resolver.mutations.ts
@@ -115,6 +115,27 @@ export class ChallengeResolverMutations {
     RestrictedGroupNames.EcoverseAdmins
   )
   @UseGuards(GqlAuthGuard)
+  @Mutation(() => UserGroup, {
+    description:
+      'Adds the user with the given identifier as a member of the specified opportunity',
+  })
+  @Profiling.api
+  async addUserToOpportunity(
+    @Args('userID') userID: number,
+    @Args('opportunityID') opportunityID: number
+  ): Promise<IUserGroup> {
+    const group = await this.challengeService.addUserToOpportunity(
+      userID,
+      opportunityID
+    );
+    return group;
+  }
+
+  @Roles(
+    RestrictedGroupNames.CommunityAdmins,
+    RestrictedGroupNames.EcoverseAdmins
+  )
+  @UseGuards(GqlAuthGuard)
   @Mutation(() => Boolean, {
     description:
       'Adds the specified organisation as a lead for the specified challenge',

--- a/src/domain/opportunity/opportunity.resolver.ts
+++ b/src/domain/opportunity/opportunity.resolver.ts
@@ -180,25 +180,4 @@ export class OpportunityResolver {
     );
     return group;
   }
-
-  @Roles(
-    RestrictedGroupNames.CommunityAdmins,
-    RestrictedGroupNames.EcoverseAdmins
-  )
-  @UseGuards(GqlAuthGuard)
-  @Mutation(() => UserGroup, {
-    description:
-      'Adds the user with the given identifier as a member of the specified opportunity',
-  })
-  @Profiling.api
-  async addUserToOpportunity(
-    @Args('userID') userID: number,
-    @Args('opportunityID') opportunityID: number
-  ): Promise<IUserGroup> {
-    const group = await this.opportunityService.addMember(
-      userID,
-      opportunityID
-    );
-    return group;
-  }
 }

--- a/src/domain/opportunity/opportunity.service.ts
+++ b/src/domain/opportunity/opportunity.service.ts
@@ -281,6 +281,22 @@ export class OpportunityService {
     return true;
   }
 
+  async getChallengeID(opportunityID: number): Promise<number> {
+    const opportunity = await this.opportunityRepository.findOne({
+      where: { id: opportunityID },
+      relations: ['challenge'],
+    });
+    if (!opportunity)
+      throw new Error(
+        `Unable to locate opportunity with the given ID: ${opportunityID}`
+      );
+    if (!opportunity.challenge)
+      throw new Error(
+        `Opportunity with given ID is not in a challenge: ${opportunityID}`
+      );
+    return opportunity.challenge.id;
+  }
+
   async createRestrictedActorGroups(
     opportunity: IOpportunity
   ): Promise<boolean> {
@@ -458,14 +474,7 @@ export class OpportunityService {
       throw new Error(msg);
     }
 
-    const opportunity = (await this.getOpportunityByID(
-      opportunityID
-    )) as Opportunity;
-    if (!opportunity) {
-      const msg = `Unable to find opportunity with ID: ${opportunityID}`;
-      this.logger.warn(msg, LogContexts.CHALLENGES);
-      throw new Error(msg);
-    }
+    const opportunity = await this.getOpportunityByID(opportunityID);
 
     // Get the members group
     const membersGroup = await this.userGroupService.getGroupByName(


### PR DESCRIPTION
An error is thrown if the user is not already a challenge member

Note:
- there is clearly room to optimise this particular mutation, but it is one that should not be happening very often. 

