### PR TITLE
Server 513. Closes #513.

### DIFF
--- a/src/utils/bootstrap/bootstrap.service.ts
+++ b/src/utils/bootstrap/bootstrap.service.ts
@@ -84,6 +84,15 @@ export class BootstrapService {
         );
       const entries = Object.entries(config);
       for (const [key, value] of entries) {
+        if (
+          key === 'loggingNoPII' &&
+          value === false &&
+          process.env.AUTH_AAD_LOGGING_PII === 'false'
+        )
+          this.logger.warn(
+            'Overriding AUTH_AAD_LOGGING_PII to true due to Microsoft passportJs bearer strategy bug https://github.com/AzureAD/passport-azure-ad/issues/521.',
+            LogContext.BOOTSTRAP
+          );
         this.logConfigLevel(key, value, '');
       }
     }
@@ -98,7 +107,10 @@ export class BootstrapService {
         this.logConfigLevel(childKey, childValue, newIndent);
       });
     } else {
-      this.logger.verbose?.(`${indent}Variable: ${key}: ${value}`);
+      this.logger.verbose?.(
+        `${indent}Variable: ${key}: ${value}`,
+        LogContext.BOOTSTRAP
+      );
     }
   }
 

--- a/src/utils/config/aad.config.ts
+++ b/src/utils/config/aad.config.ts
@@ -10,9 +10,7 @@ export default registerAs('aad', () => ({
   allowMultiAudiencesInToken: false,
   loggingLevel: process.env.AUTH_AAD_LOGGING_LEVEL || AAD_LOGGING_LEVEL.Error,
   scope: ['Cherrytwist-GraphQL'],
-  loggingNoPII: !(
-    process.env.AUTH_AAD_LOGGING_PII?.toString().toLocaleLowerCase() === 'true'
-  ),
+  loggingNoPII: false,
   upnDomain:
     process.env.AUTH_AAD_UPN_DOMAIN || 'playgroundcherrytwist.onmicrosoft.com',
   tenant: process.env.AUTH_AAD_TENANT || '',


### PR DESCRIPTION
### Describe the background of your pull request

Returns TokenException with CherrytwistErrorStatus.TOKEN_EXPIRED when JWT token has expired.

### Additional context

Works only with AUTH_AAD_LOGGING_PII=true. Microsoft has decided that verbose validation logging needs PII. Go figure.
The culprit is on line 330 in the passport-azure-ad/lib/bearerstrategy.js (you can find it in the node_modules after npm install).

    if (err) {
      if (err.message && !self._options.loggingNoPII)
        return self.failWithLog(err.message);
      else
        return self.failWithLog('In Strategy.prototype.jwtVerify: cannot verify token');
    }

There is a bunch of code similar to this one in the library.

### Governance 

- [x] I've read the contributing document https://github.com/cherrytwist/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/cherrytwist/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/cherrytwist/Coordination/blob/master/LICENSE 
     and the contributor license agreement: tba
 
