### PR TITLE
Removed the default Collaborators in Opportunity Actor Groups. Removed duplicate enum.

### DIFF
--- a/src/domain/actor/actor.entity.ts
+++ b/src/domain/actor/actor.entity.ts
@@ -10,10 +10,6 @@ import {
 import { ActorGroup } from '../actor-group/actor-group.entity';
 import { IActor } from './actor.interface';
 
-export enum RestrictedActorGroupNames {
-  Collaborators = 'collaborators',
-}
-
 @Entity()
 @ObjectType()
 export class Actor extends BaseEntity implements IActor {

--- a/src/domain/opportunity/opportunity.entity.ts
+++ b/src/domain/opportunity/opportunity.entity.ts
@@ -12,10 +12,7 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { IGroupable } from '../../interfaces/groupable.interface';
-import {
-  ActorGroup,
-  RestrictedActorGroupNames,
-} from '../actor-group/actor-group.entity';
+import { ActorGroup } from '../actor-group/actor-group.entity';
 import { Aspect } from '../aspect/aspect.entity';
 import { Challenge } from '../challenge/challenge.entity';
 import { Context } from '../context/context.entity';
@@ -127,6 +124,6 @@ export class Opportunity extends BaseEntity
     this.textID = textID;
     this.state = '';
     this.restrictedGroupNames = [RestrictedGroupNames.Members];
-    this.restrictedActorGroupNames = [RestrictedActorGroupNames.Collaborators];
+    this.restrictedActorGroupNames = [];
   }
 }

--- a/src/domain/opportunity/opportunity.service.ts
+++ b/src/domain/opportunity/opportunity.service.ts
@@ -353,21 +353,6 @@ export class OpportunityService {
     return true;
   }
 
-  // Get the default ActorGroup
-  getCollaboratorsActorGroup(
-    opportunity: IOpportunity
-  ): IActorGroup | undefined {
-    if (!opportunity.actorGroups)
-      throw new EntityNotInitializedException(
-        'actorGroups not initialised',
-        LogContext.CHALLENGES
-      );
-    const collaboratorsActorGroup = opportunity.actorGroups.find(
-      t => t.name === RestrictedActorGroupNames.Collaborators
-    );
-    return collaboratorsActorGroup;
-  }
-
   async createProject(
     opportunityId: number,
     projectData: ProjectInput


### PR DESCRIPTION
Removed the default Collaborators in Opportunity Actor Groups. Removed duplicate enum.

I have kept one of the enums - I don't know whether it's needed. If we aren't going to use it - I can remove it. Also there is getCollaboratorsActorGroup in the OpportunityService - if we aren't going to use I can remove it as well.